### PR TITLE
fix: change env variables according to RHOAS configs

### DIFF
--- a/consumer-backend/consumer.js
+++ b/consumer-backend/consumer.js
@@ -28,8 +28,8 @@ try {
   if (process.env.KAFKA_SASL_MECHANISM === 'plain') {
     kafkaConnectionBindings.sasl = {
       mechanism: process.env.KAFKA_SASL_MECHANISM,
-      username: process.env.RHOAS_CLIENT_ID,
-      password: process.env.RHOAS_CLIENT_SECRET
+      username: process.env.RHOAS_SERVICE_ACCOUNT_CLIENT_ID,
+      password: process.env.RHOAS_SERVICE_ACCOUNT_CLIENT_SECRET
     };
     kafkaConnectionBindings.ssl = true;
   }

--- a/producer-backend/producer.js
+++ b/producer-backend/producer.js
@@ -19,8 +19,8 @@ try {
   if (process.env.KAFKA_SASL_MECHANISM === 'plain') {
     kafkaConnectionBindings.sasl = {
       mechanism: process.env.KAFKA_SASL_MECHANISM,
-      username: process.env.RHOAS_CLIENT_ID,
-      password: process.env.RHOAS_CLIENT_SECRET
+      username: process.env.RHOAS_SERVICE_ACCOUNT_CLIENT_ID,
+      password: process.env.RHOAS_SERVICE_ACCOUNT_CLIENT_SECRET
     };
     kafkaConnectionBindings.ssl = true;
   }


### PR DESCRIPTION
This PR changes the environment variables to the ones generated by RHOAS CLI service account creation.

Other existing examples have been updated in https://github.com/redhat-developer/app-services-guides/pull/561.